### PR TITLE
Update base repo URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ MAINTAINER_REPO='https://github.com/Webysther/packagist-mirror'
 MAINTAINER_LICENSE='MIT License'
 
 # Main mirror used to get providers
-MAIN_MIRROR=https://packagist.org
+MAIN_MIRROR=https://repo.packagist.org
 
 # Timezone
 TZ='America/Sao_Paulo'


### PR DESCRIPTION
repo.packagist.org is the new domain for the metadata (/packages.json and /p/*). Existing mirror instances should be updated too ideally.