### PR TITLE
Expose URI patterns to support mirroring third party repos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ MAINTAINER_LICENSE='MIT License'
 # UK - https://repo-eu-uk-1.packagist.org
 MAIN_MIRROR=https://repo.packagist.org
 
+# Pattern to generate the package URIs.
+# I.E. packages.drupal.org uses: URI_PATTERN='%s$%s.json'
+URI_PATTERN='p/%s$%s.json'
+
 # Timezone
 TZ='America/Sao_Paulo'
 

--- a/bin/mirror
+++ b/bin/mirror
@@ -49,7 +49,7 @@ $cli = new Symfony\Component\Console\Application(
 
 $filesystem = new Webs\Mirror\Filesystem(getenv('PUBLIC_DIR'));
 $provider = new Webs\Mirror\Provider;
-$package = new Webs\Mirror\Package;
+$package = new Webs\Mirror\Package(getenv('URI_PATTERN'));
 $progressBar = new Webs\Mirror\ProgressBar;
 
 $mirror = new Webs\Mirror\Mirror(

--- a/src/Package.php
+++ b/src/Package.php
@@ -45,9 +45,22 @@ class Package
     protected $mainJson;
 
     /**
+     * @var $uriPattern
+     */
+    protected $uriPattern;
+
+    /**
      * Main files.
      */
     const MAIN = Base::MAIN;
+
+    /**
+     * @param string $uriPattern Pattern to find the package json files.
+     */
+    public function __construct($uriPattern)
+    {
+        $this->uriPattern = $uriPattern;
+    }
 
     /**
      * Add a http.
@@ -122,14 +135,14 @@ class Package
 
     /**
      * @param stdClass $providers List of individual packages as a list
-     * 
+     *
      * @return array
      */
     public function normalize(stdClass $providers):array
     {
         $providerPackages = [];
         foreach ($providers as $name => $hash) {
-            $uri = sprintf('p/%s$%s.json', $name, $hash->sha256);
+            $uri = sprintf($this->uriPattern, $name, $hash->sha256);
             $providerPackages[$uri] = $hash->sha256;
         }
 

--- a/tests/Command/CreateTest.php
+++ b/tests/Command/CreateTest.php
@@ -41,7 +41,7 @@ class CreateTest extends TestCase
         $filesystem = new Filesystem($this->dir);
         $filesystem->setFilesystem($fly);
         $provider = new Provider;
-        $package = new Package;
+        $package = new Package(getenv('URI_PATTERN'));
 
         $progressBar = new ProgressBar;
 

--- a/tests/fixture/.env
+++ b/tests/fixture/.env
@@ -24,5 +24,7 @@ MAIN_MIRROR=https://packagist.org
 # China - https://packagist.phpcomposer.com (not fully compatible - too much broken packages)
 DATA_MIRROR=https://packagist.jp,https://packagist.com.br,https://packagist.phpindonesia.id
 
+URI_PATTERN='p/%s$%s.json'
+
 # Max connections by mirror
 MAX_CONNECTIONS=25


### PR DESCRIPTION
Some third-party composer repos, like packages.drupal.org, use a slightly different URI pattern for the packages json files.

This PR makes that URI pattern configurable in the environment so that they can configured to mirror repos configured this way.